### PR TITLE
Proper Alias System

### DIFF
--- a/lua/autorun/xadmin_init.lua
+++ b/lua/autorun/xadmin_init.lua
@@ -21,6 +21,8 @@ end
 if SERVER then
 	AddCSLuaFile("xadmin/_config/sh_permissions.lua")
 	include("xadmin/_config/sh_permissions.lua")
+
+	include("xadmin/core/sv_db.lua")
 else
 	include("xadmin/_config/sh_permissions.lua")
 end
@@ -90,7 +92,9 @@ local function loadFolder(path, ignore)
 		end
 	end
 end
-loadFolder("xadmin/core/")
+loadFolder("xadmin/core/", {
+	["xadmin/core/sv_db.lua"] = true,
+})
 loadFolder("xadmin/_config/", {
 	["xadmin/_config/sh_permissions.lua"] = true, -- We dont need to load it twice
 })

--- a/lua/xadmin/_config/sh_permissions.lua
+++ b/lua/xadmin/_config/sh_permissions.lua
@@ -65,6 +65,7 @@ xAdmin.Config.PowerlevelPermissions = {
 	["strip"] 		= 70,
 	["give"] 		= 70,
 	["help"]		= 0,
+	["extrahelp"]	= 0,
 
 	-- Addon: xWarn --
 	["warn"]		= 30,

--- a/lua/xadmin/commands/groups.lua
+++ b/lua/xadmin/commands/groups.lua
@@ -32,7 +32,7 @@ xAdmin.Core.RegisterCommand("setgroup", "Set a user's group", xAdmin.Config.Powe
 		xAdmin.Database.UpdateUsersGroup(target, xAdmin.Database.Escape(args[2]))
 	end
 	hook.Run("xAdminUsergroupUpdated", target, args[2])
-end)
+end, {"setrank"})
 
 --- #
 --- # GET USERGROUP
@@ -63,4 +63,4 @@ xAdmin.Core.RegisterCommand("getgroup", "Get a user's group", xAdmin.Config.Powe
 			xAdmin.Core.Msg({targetID .. "'s usergroup is: " .. data[1].rank}, admin)
 		end)
 	end
-end)
+end, {"getrank"})

--- a/lua/xadmin/commands/misc.lua
+++ b/lua/xadmin/commands/misc.lua
@@ -39,12 +39,4 @@ xAdmin.Core.RegisterCommand("steamid", "Gets a user's SteamID64", xAdmin.Config.
 	end
 
 	xAdmin.Core.Msg({target, "'s SteamID: " .. target:SteamID64()}, admin)
-end)
-
-xAdmin.Core.RegisterCommand("sid", "Alias of steamid", xAdmin.Config.PowerlevelPermissions["steamid"], function(admin, args)
-	xAdmin.Commands["steamid"].func(admin, args)
-end)
-
-xAdmin.Core.RegisterCommand("id", "Alias of steamid", xAdmin.Config.PowerlevelPermissions["steamid"], function(admin, args)
-	xAdmin.Commands["steamid"].func(admin, args)
-end)
+end, {"sid", "id"})

--- a/lua/xadmin/commands/util.lua
+++ b/lua/xadmin/commands/util.lua
@@ -124,11 +124,7 @@ xAdmin.Core.RegisterCommand("health", "Set a user's health", xAdmin.Config.Power
 	end -- Remove
 
 	xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "Unable to determine what operation to use with the value you specified."}, admin)
-end)
-
-xAdmin.Core.RegisterCommand("hp", "Alias for health", xAdmin.Config.PowerlevelPermissions["health"], function(admin, args)
-	xAdmin.Commands["health"].func(admin, args)
-end)
+end, {"hp"})
 
 --- #
 --- # ARMOR
@@ -220,7 +216,7 @@ xAdmin.Core.RegisterCommand("armor", "Set a user's armor", xAdmin.Config.Powerle
 	end -- Remove
 
 	xAdmin.Core.Msg({xAdmin.Config.ColorLogText, "Unable to determine what operation to use with the value you specified."}, admin)
-end)
+end, {"ap"})
 
 --- #
 --- # GOD
@@ -280,11 +276,7 @@ xAdmin.Core.RegisterCommand("slay", "Kill a user", xAdmin.Config.PowerlevelPermi
 
 	target:Kill()
 	xAdmin.Core.Msg({admin, " has slayed ", target})
-end)
-
-xAdmin.Core.RegisterCommand("kill", "Alias for slay", xAdmin.Config.PowerlevelPermissions["slay"], function(admin, args)
-	xAdmin.Commands["slay"].func(admin, args)
-end)
+end, {"kill"})
 
 --- #
 --- # REVIVE
@@ -312,7 +304,7 @@ xAdmin.Core.RegisterCommand("revive", "Revive a user", xAdmin.Config.PowerlevelP
 	target:Spawn()
 	target:SetPos(deathPos)
 	xAdmin.Core.Msg({admin, " has revived ", target})
-end)
+end, {"rev"})
 
 --- #
 --- # RESPAWN
@@ -332,7 +324,7 @@ xAdmin.Core.RegisterCommand("respawn", "Respawn a user", xAdmin.Config.Powerleve
 
 	target:Spawn()
 	xAdmin.Core.Msg({admin, " has respawned ", target})
-end)
+end, {"res"})
 
 --- #
 --- # STRIP
@@ -352,10 +344,7 @@ xAdmin.Core.RegisterCommand("strip", "Strip a user", xAdmin.Config.PowerlevelPer
 
 	target:StripWeapons()
 	xAdmin.Core.Msg({admin, " has stripped ", target})
-end)
-xAdmin.Core.RegisterCommand("stripweapons", "Alias for strip", xAdmin.Config.PowerlevelPermissions["strip"], function(admin, args)
-	xAdmin.Commands["strip"].func(admin, args)
-end)
+end, {"stripweapons"})
 
 --- #
 --- # GIVE
@@ -375,10 +364,8 @@ xAdmin.Core.RegisterCommand("give", "Give a user a weapon", xAdmin.Config.Powerl
 
 	target:Give(args[2] or "weapon_357")
 	xAdmin.Core.Msg({admin, " has given ", target, " a ", Color(138, 43, 226), args[2] or "weapon_357"})
-end)
-xAdmin.Core.RegisterCommand("giveweapon", "Alias for give", xAdmin.Config.PowerlevelPermissions["give"], function(admin, args)
-	xAdmin.Commands["give"].func(admin, args)
-end)
+end, {"giveweapon"})
+
 -- xAdmin.CommandCache
 xAdmin.Core.RegisterCommand("help", "Get help with the addon.", xAdmin.Config.PowerlevelPermissions["help"], function(admin, args)
 	local str = ""

--- a/lua/xadmin/core/sv_commands.lua
+++ b/lua/xadmin/core/sv_commands.lua
@@ -1,4 +1,13 @@
-function xAdmin.Core.RegisterCommand(command, desc, power, func)
+function xAdmin.Core.RegisterCommandInternal(cmd, dsc, pwr, fnc)
+	xAdmin.Commands[cmd] = {
+		command = cmd,
+		desc = dsc or "n/a",
+		power = xAdmin.Config.PowerlevelPermissions[cmd] or xAdmin.Config.PowerLevelDefault,
+		func = fnc
+	}
+end
+
+function xAdmin.Core.RegisterCommand(command, desc, power, func, alias)
 	if not command then
 		return
 	end
@@ -7,12 +16,22 @@ function xAdmin.Core.RegisterCommand(command, desc, power, func)
 		return
 	end
 
-	xAdmin.Commands[command] = {
-		command = command,
-		desc = desc or "n/a",
-		power = xAdmin.Config.PowerlevelPermissions[command] or xAdmin.Config.PowerLevelDefault,
-		func = func
-	}
+	// xAdmin.Commands[command] = {
+	// 	command = command,
+	// 	desc = desc or "n/a",
+	// 	power = xAdmin.Config.PowerlevelPermissions[command] or xAdmin.Config.PowerLevelDefault,
+	// 	func = func
+	// }
+	print("[xAdmin] Loading command " .. command .. ".")
+	xAdmin.Core.RegisterCommandInternal(command, desc, power, func)
+
+	if alias then
+		if not istable(alias) then return end
+		for k, v in pairs(alias) do
+			xAdmin.Core.RegisterCommandInternal(v, desc, power, func)
+			print("", "Alias Registered: " .. v)
+		end
+	end
 end
 function xAdmin.Core.IsCommand(arg)
 	return xAdmin.Commands[arg] or false


### PR DESCRIPTION
Cleaned up the way aliases used to be made, they no longer require creating another command entirely. Just add a table as the last argument in the xAdmin.Core.RegisterCommand function.

Example:
![image](https://user-images.githubusercontent.com/59421259/130304209-dc9660d0-b22c-46ed-a561-a0d17837ebf9.png)

(also makes it work with the new permission table added in the last PR i made)