### PR TITLE
Fixing the prop hooks not being added if enabled

### DIFF
--- a/lua/xadmin/core/sv_core.lua
+++ b/lua/xadmin/core/sv_core.lua
@@ -175,27 +175,3 @@ function xAdmin.Core.Msg(args, target)
 
 	MsgC("\n")
 end
-
---
--- Prop Limit
---
-if xAdmin.Config.PropLimit then
-	hook.Add("PlayerSpawnProp", "xAdminPropLimit", function(ply, model)
-		local count = ply:GetCount("props") + 1
-		local limit = ply:GetGroupTable().proplimit or xAdmin.Config.DefaultPropLimit
-
-		if limit == -1 then
-			return true
-		end
-
-		if count > limit then xAdmin.Core.Msg({string.format("You have reached your prop limit of %s/%s", limit, limit)}, ply) return false end
-	end)
-
-	hook.Add("PlayerSpawnedProp", "xAdminPropLimitNotify", function(ply, model)
-		local count = ply:GetCount("props") + 1
-		local limit = ply:GetGroupTable().proplimit or xAdmin.Config.DefaultPropLimit
-		if not xAdmin.Config.PropLimitNotify then return end
-
-		xAdmin.Core.Msg({string.format("You have spawned a prop. You're now at %s/%s", count, (limit == -1) and xAdmin.Config.PropLimitInfinText or limit) }, ply)
-	end)
-end

--- a/lua/xadmin/extras/sv_other.lua
+++ b/lua/xadmin/extras/sv_other.lua
@@ -33,3 +33,27 @@ for k, v in pairs(xAdmin.Config.CustomConsoleCommands) do
 		end)
 	end
 end
+
+--
+-- Prop Limit
+--
+if xAdmin.Config.PropLimit then
+	hook.Add("PlayerSpawnProp", "xAdminPropLimit", function(ply, model)
+		local count = ply:GetCount("props") + 1
+		local limit = ply:GetGroupTable().proplimit or xAdmin.Config.DefaultPropLimit
+
+		if limit == -1 then
+			return true
+		end
+
+		if count > limit then xAdmin.Core.Msg({string.format("You have reached your prop limit of %s/%s", limit, limit)}, ply) return false end
+	end)
+
+	hook.Add("PlayerSpawnedProp", "xAdminPropLimitNotify", function(ply, model)
+		local count = ply:GetCount("props") + 1
+		local limit = ply:GetGroupTable().proplimit or xAdmin.Config.DefaultPropLimit
+		if not xAdmin.Config.PropLimitNotify then return end
+
+		xAdmin.Core.Msg({string.format("You have spawned a prop. You're now at %s/%s", count, (limit == -1) and xAdmin.Config.PropLimitInfinText or limit) }, ply)
+	end)
+end

--- a/lua/xadmin/extras/sv_other.lua
+++ b/lua/xadmin/extras/sv_other.lua
@@ -49,11 +49,12 @@ if xAdmin.Config.PropLimit then
 		if count > limit then xAdmin.Core.Msg({string.format("You have reached your prop limit of %s/%s", limit, limit)}, ply) return false end
 	end)
 
-	hook.Add("PlayerSpawnedProp", "xAdminPropLimitNotify", function(ply, model)
-		local count = ply:GetCount("props") + 1
-		local limit = ply:GetGroupTable().proplimit or xAdmin.Config.DefaultPropLimit
-		if not xAdmin.Config.PropLimitNotify then return end
+	if xAdmin.Config.PropLimitNotify then
+		hook.Add("PlayerSpawnedProp", "xAdminPropLimitNotify", function(ply, model)
+			local count = ply:GetCount("props") + 1
+			local limit = ply:GetGroupTable().proplimit or xAdmin.Config.DefaultPropLimit
 
-		xAdmin.Core.Msg({string.format("You have spawned a prop. You're now at %s/%s", count, (limit == -1) and xAdmin.Config.PropLimitInfinText or limit) }, ply)
-	end)
+			xAdmin.Core.Msg({string.format("You have spawned a prop. You're now at %s/%s", count, (limit == -1) and xAdmin.Config.PropLimitInfinText or limit) }, ply)
+		end)
+	end
 end


### PR DESCRIPTION
sv_core.lua loads before the sh_config.lua so the "xAdmin.Config.PropLimitNotify" will always be false and the hooks won't be added - move the code to the extras sv file which loads after

**EDIT:** I also made sure we don't add any useless hooks that are continuously run if we're just going to return out of them.